### PR TITLE
fix: hello world example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.12.0-bookworm
 
+# This is building the testing container
+# docker build -t vanessa/snakemake:kueue .
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git
 
@@ -7,6 +10,7 @@ RUN pip3 install -U git+https://github.com/snakemake/snakemake-interface-common@
     pip3 install -U git+https://github.com/snakemake/snakemake-interface-executor-plugins && \
     pip3 install -U git+https://github.com/snakemake/snakemake-interface-storage-plugins@main && \
     pip3 install -U git+https://github.com/snakemake/snakemake-storage-plugin-s3@main && \
+    pip3 install -U git+https://github.com/snakemake/snakemake-storage-plugin-gcs@main && \
     pip3 install -U git+https://github.com/snakemake/snakemake@main
     
 # Wrappers to ensure we source the mamba environment!

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ that has clones from main branches (as opposed to releases).
 You will need to create a cluster first. For local development we recommend [kind](https://kind.sigs.k8s.io/docs/user/quick-start/#installing-from-source):
 
 ```bash
-$ kind create cluster
+kind create cluster
 ```
 
 #### Install Kueue
@@ -36,9 +36,14 @@ kubectl  apply -f example/cluster-queue.yaml
 kubectl  apply -f example/resource-flavor.yaml 
 kubectl  apply -f example/user-queue.yaml 
 ```
+```console
+clusterqueue.kueue.x-k8s.io/cluster-queue created
+resourceflavor.kueue.x-k8s.io/default-flavor created
+localqueue.kueue.x-k8s.io/user-queue created
+```
 
-You'll also need kubernetes python installed, and of course Snakemake! Assuming you have snakemake and the plugin here installed, you should be good
-to go. Here is how I setup a local or development environment.
+You'll also need kubernetes python installed, and of course Snakemake! Assuming you have snakemake and the plugin here installed, you should be good to go.
+Here is how I setup a local or development environment.
 
 ```bash
 python -m venv env
@@ -46,7 +51,9 @@ source env/bin/activate
 pip install .
 ```
 
-Next go into an [example](example) directory to test out the Kueue executor.
+### Container
+
+Note that while Snakemake still has a lot of moving pieces, the default container is built from the [Dockerfile](Dockerfile) here and provided as `vanessa/snakemake:kueue` in the executor code. Next go into an [example](example) directory to test out the Kueue executor.
 
 ### Job Resources
 

--- a/example/README.md
+++ b/example/README.md
@@ -3,4 +3,4 @@
 The following examples demonstrate using the kueue plugin.
 
  - [hello-world](hello-world): a basic getting started workflow.
- - [snakemake-tutorial](snakemake-tutorial): the official Snakemake tutorial with data
+ - [flux-operator](flux-operator): An example of using the flux operator to run MPI jobs

--- a/example/hello-world/README.md
+++ b/example/hello-world/README.md
@@ -4,5 +4,74 @@ Given that you've installed Kueue (see the main [README](../README.md)) and have
 to choose a storage provider, and then:
 
 ```bash
-$ snakemake --cores 1 --executor kueue --jobs 1 --default-storage-provider s3 --default-storage-prefix s3://snakemake-testing-llnl
+snakemake --cores 1 --executor kueue --jobs 1 --default-storage-provider s3 --default-storage-prefix s3://snakemake-testing-llnl
 ```
+```console
+Building DAG of jobs...
+Uploading source archive to storage provider...
+Using shell: /usr/bin/bash
+Provided remote nodes: 1
+Job stats:
+job            count
+-----------  -------
+all                1
+hello_world        2
+total              3
+
+Select jobs to execute...
+Execute 1 jobs...
+
+[Tue Jan  2 23:08:51 2024]
+rule hello_world:
+    output: s3://snakemake-testing-llnl/hola1/world.txt (send to storage)
+    jobid: 2
+    reason: Missing output files: s3://snakemake-testing-llnl/hola1/world.txt (send to storage)
+    wildcards: greeting=hola1
+    resources: tmpdir=<TBD>, kueue_operator=job
+
+Use:
+'kubectl get queue' to see queue assignment 'kubectl get jobs' to see jobs'
+JobStatus.ACTIVE
+JobStatus.ACTIVE
+JobStatus.ACTIVE
+JobStatus.SUCCEEDED
+[Tue Jan  2 23:09:32 2024]
+Finished job 2.
+1 of 3 steps (33%) done
+Select jobs to execute...
+Execute 1 jobs...
+
+[Tue Jan  2 23:09:32 2024]
+rule hello_world:
+    output: s3://snakemake-testing-llnl/hello1/world.txt (send to storage)
+    jobid: 1
+    reason: Missing output files: s3://snakemake-testing-llnl/hello1/world.txt (send to storage)
+    wildcards: greeting=hello1
+    resources: tmpdir=<TBD>, kueue_operator=job
+
+Use:
+'kubectl get queue' to see queue assignment 'kubectl get jobs' to see jobs'
+JobStatus.ACTIVE
+JobStatus.ACTIVE
+JobStatus.ACTIVE
+JobStatus.SUCCEEDED
+[Tue Jan  2 23:10:12 2024]
+Finished job 1.
+2 of 3 steps (67%) done
+Select jobs to execute...
+Execute 1 jobs...
+
+[Tue Jan  2 23:10:12 2024]
+localrule all:
+    input: s3://snakemake-testing-llnl/hello1/world.txt (retrieve from storage), s3://snakemake-testing-llnl/hola1/world.txt (retrieve from storage)
+    jobid: 0
+    reason: Input files updated by another job: s3://snakemake-testing-llnl/hello1/world.txt (retrieve from storage), s3://snakemake-testing-llnl/hola1/world.txt (retrieve from storage)
+    resources: tmpdir=/tmp
+
+[Tue Jan  2 23:10:12 2024]
+Finished job 0.
+3 of 3 steps (100%) done
+Complete log: .snakemake/log/2024-01-02T230850.765184.snakemake.log
+```
+
+In the above we take advantage of Snakemake's ability to use remotes to get around the issue that Kubernetes isn't great with storage. :)

--- a/snakemake_executor_plugin_kueue/__init__.py
+++ b/snakemake_executor_plugin_kueue/__init__.py
@@ -50,6 +50,7 @@ common_settings = CommonSettings(
     # (cluster, cloud, etc.). Only Snakemake's standard execution
     # plugins (snakemake-executor-plugin-dryrun, snakemake-executor-plugin-local)
     # are expected to specify False here.
+    job_deploy_sources=True,
     non_local_exec=True,
     pass_default_storage_provider_args=True,
     implies_no_shared_fs=True,

--- a/snakemake_executor_plugin_kueue/utils.py
+++ b/snakemake_executor_plugin_kueue/utils.py
@@ -1,10 +1,16 @@
-def write_file(content, filename):
+def write_file(content, filename, mode="w"):
     """
     Write content to file.
     """
-    print(filename)
-    with open(filename, "w") as fd:
+    with open(filename, mode) as fd:
         fd.write(content)
+
+
+def append_file(content, filename):
+    """
+    Append content to file.
+    """
+    return write_file(content, filename, "a")
 
 
 def read_file(filename):


### PR DESCRIPTION
The example for hello-world was not working, I was trying to use a hack for storage, and more appropriately I should use snakemake built in remotes to start. This will run the entire hello world example workflow, using a container I built that will eventually be updated to snakemake releases when development is done.

I'll go back to the flux operator example next, and that will be super cool because snakemake will be running MPI jobs in Kubernetes!